### PR TITLE
Fix issues with TCX files

### DIFF
--- a/dist/tcx.js
+++ b/dist/tcx.js
@@ -53,7 +53,7 @@ var Tcx = exports.Tcx = function () {
               Id: new Date(data.start_epoch_ms).toISOString(),
               Lap: {
                 '@StartTime': new Date(data.start_epoch_ms).toISOString(),
-                TotalTimeSeconds: data.active_duration_ms,
+                TotalTimeSeconds: (data.active_duration_ms / 1000.0).toString(),
                 DistanceMeters: !!_nikeHelper.NikeHelper.GetSummary(data, 'distance') ? _nikeHelper.NikeHelper.GetSummary(data, 'distance').value * 1000 : null,
                 MaximumSpeed: !!speeds ? speeds.map(function (s) {
                   return s.value;

--- a/dist/tcx.js
+++ b/dist/tcx.js
@@ -99,7 +99,7 @@ var Tcx = exports.Tcx = function () {
           }) };
       }
 
-      latitudes.forEach(function (item, index) {
+      (latitudes || []).forEach(function (item, index) {
         return trackPoints.push({
           Time: item.end_epoch_ms,
           Position: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nikeplus-client",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nikeplus-client",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nikeplus-client",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Simple Nike+ client",
   "main": "dist/nike.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nikeplus-client",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Simple Nike+ client",
   "main": "dist/nike.js",
   "scripts": {

--- a/src/tcx.js
+++ b/src/tcx.js
@@ -28,7 +28,7 @@ export class Tcx {
             Id: new Date(data.start_epoch_ms).toISOString(),
             Lap: {
               '@StartTime':new Date(data.start_epoch_ms).toISOString(),
-              TotalTimeSeconds: data.active_duration_ms,
+              TotalTimeSeconds: (data.active_duration_ms / 1000.0).toString(),
               DistanceMeters: !!NikeHelper.GetSummary(data, 'distance') ? NikeHelper.GetSummary(data, 'distance').value * 1000 : null,
               MaximumSpeed: !!speeds ? speeds.map((s) => s.value).reduce((prev, next) => Math.max(prev, next)) * 0.277778 : null, //km/h --> m/s
               Calories: !!NikeHelper.GetSummary(data,'calories') ? NikeHelper.GetSummary(data,'calories').value : null,

--- a/src/tcx.js
+++ b/src/tcx.js
@@ -66,7 +66,7 @@ export class Tcx {
       result.TrainingCenterDatabase.Activities.Activity.Lap.MaximumHeartRateBpm = {Value: heartRates.map((h) => h.value).reduce((prev, next) => Math.max(prev, next))}
     }
 
-    latitudes.forEach((item, index) => trackPoints.push({
+    (latitudes||[]).forEach((item, index) => trackPoints.push({
           Time: item.end_epoch_ms,
           Position: {
             LatitudeDegrees: latitudes[index].value,


### PR DESCRIPTION
* Runs may not have GPS track (e.g. from treadmill) but we can still write a TCX summary. Fix issue where TCX processing assumes GPS track will be present.
* TCX time in seconds was outputting time in milliseconds instead. This is a double field in the XML so a simple division should work.